### PR TITLE
Fix for loading scripts with query parameters in path.

### DIFF
--- a/ClientDependency.Core/FileRegistration/Providers/BaseFileRegistrationProvider.cs
+++ b/ClientDependency.Core/FileRegistration/Providers/BaseFileRegistrationProvider.cs
@@ -182,6 +182,7 @@ namespace ClientDependency.Core.FileRegistration.Providers
             foreach (var f in dependencies)
             {
                 //need to parse out the request's extensions and remove query strings
+                //need to force non-bundled lines for items with query parameters.
                 var extension = f.FilePath.Contains('?') ? "" :  Path.GetExtension(f.FilePath);
                 var stringExt = "";
                 if (!string.IsNullOrWhiteSpace(extension))


### PR DESCRIPTION
GetExtension can't be called on url's with query parameters. 
They need to be force leaded as independent files not a bundle.
