### PR TITLE
Added fixes for resource url's that include hash values.

### DIFF
--- a/ClientDependency.Core/FileRegistration/Providers/BaseFileRegistrationProvider.cs
+++ b/ClientDependency.Core/FileRegistration/Providers/BaseFileRegistrationProvider.cs
@@ -188,8 +188,8 @@ namespace ClientDependency.Core.FileRegistration.Providers
             foreach (var f in dependencies)
             {
                 //need to parse out the request's extensions and remove query strings
-                //need to force non-bundled lines for items with query parameters.
-                var extension = f.FilePath.Contains('?') ? "" :  Path.GetExtension(f.FilePath);
+                //need to force non-bundled lines for items with query parameters or a hash value.
+                var extension = f.FilePath.Contains('?') || f.FilePath.Contains('#') ? "" : Path.GetExtension(f.FilePath);
                 var stringExt = "";
                 if (!string.IsNullOrWhiteSpace(extension))
                 {
@@ -338,10 +338,15 @@ namespace ClientDependency.Core.FileRegistration.Providers
                 if (url.Contains("cdv=" + ClientDependencySettings.Instance.Version))
                     return url;
 
+                //move hash to the end of the file name if present. Eg: /s/myscript.js?cdv=3#myhash
+                var hash = url.Contains("#") ? "#" + url.Split(new[] { '#' }, 2)[1] : "";
+                if (!String.IsNullOrEmpty(hash))
+                    url = url.Split(new[] { '#' }, 2)[0];
+
                 //ensure there's not duplicated query string syntax
                 url += url.Contains('?') ? "&" : "?";
                 //append a version
-                url += "cdv=" + ClientDependencySettings.Instance.Version;
+                url += "cdv=" + ClientDependencySettings.Instance.Version + hash;
             }
             else
             {


### PR DESCRIPTION
Two changes:
  Change the AppendVersion to generate valid url's when a hash value is present.
  Explicitly disable bundling of urls with a # in them. (This already happens for ?'s).

This is primarily done when integrating external javascript libraries into a site.  So it really only happens with external resources, but this fix fixes it for local and remove resources.  A example of this in the real world would be the AddThis social sharing framework.  To use that you would call the following:

Html.RequiresJs("//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-############");

This was incorrectly rendering as 
/s7.addthis.com/js/300/addthis_widget.js#pubid=ra-############?cdv=1
Instead of the correct 
/s7.addthis.com/js/300/addthis_widget.js?cdv=1#pubid=ra-############
