### PR TITLE
File path canonicalization

### DIFF
--- a/ClientDependency.Core/IClientDependencyFileExtensions.cs
+++ b/ClientDependency.Core/IClientDependencyFileExtensions.cs
@@ -30,16 +30,17 @@ namespace ClientDependency.Core
             {
                 return file.FilePath; 
             }
-            if (!http.IsAbsolute(file.FilePath))
+
+            var filePath = file.FilePath;
+            if (!http.IsAbsolute(filePath))
             {
                 //get the relative path
                 var path = http.Request.AppRelativeCurrentExecutionFilePath.Substring(0, http.Request.AppRelativeCurrentExecutionFilePath.LastIndexOf('/') + 1);
-                return http.ResolveUrl(path + file.FilePath);
+                filePath = http.ResolveUrl(path + filePath);
             }
-            return file.FilePath;
+
+            var uri = new Uri(new Uri("https://example.com"), filePath);
+            return uri.PathAndQuery;
         }
-
-        
-
     }
 }

--- a/ClientDependency.UnitTests/ClientDependency.UnitTests.csproj
+++ b/ClientDependency.UnitTests/ClientDependency.UnitTests.csproj
@@ -130,6 +130,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="CssTransformTest.cs" />
     <Compile Include="RogueFileFilterTest.cs" />
+    <Compile Include="ResolveFilePathTest.cs" />
     <Compile Include="StringExtensionsTest.cs" />
     <Compile Include="TypeScriptTests.cs" />
   </ItemGroup>

--- a/ClientDependency.UnitTests/ResolveFilePathTest.cs
+++ b/ClientDependency.UnitTests/ResolveFilePathTest.cs
@@ -80,5 +80,30 @@ namespace ClientDependency.UnitTests
 
             Assert.AreEqual("/the/path/file.js", resolvedPath);
         }
+
+        [Test]
+        public void NonCanonicalRelativePath_IsCanonicalized()
+        {
+            var mockHttp = Mock.Of<HttpContextBase>();
+            Mock.Get(mockHttp).DefaultValue = DefaultValue.Mock;
+            Mock.Get(mockHttp.Request).Setup(r => r.AppRelativeCurrentExecutionFilePath).Returns("/the/path/page.aspx");
+
+            var file = new BasicFile(ClientDependencyType.Javascript) { FilePath = "../file.js", };
+
+            var resolvedPath = file.ResolveFilePath(mockHttp);
+
+            Assert.AreEqual("/the/file.js", resolvedPath);
+        }
+
+        [Test]
+        public void NonCanonicalAbsolutePath_IsCanonicalized()
+        {
+            var mockHttp = Mock.Of<HttpContextBase>();
+            var file = new BasicFile(ClientDependencyType.Javascript) { FilePath = "/website/folder/../js.js", };
+
+            var resolvedPath = file.ResolveFilePath(mockHttp);
+
+            Assert.AreEqual("/website/js.js", resolvedPath);
+        }
     }
 }

--- a/ClientDependency.UnitTests/ResolveFilePathTest.cs
+++ b/ClientDependency.UnitTests/ResolveFilePathTest.cs
@@ -1,0 +1,84 @@
+using ClientDependency.Core;
+using NUnit.Framework;
+
+namespace ClientDependency.UnitTests
+{
+    using System;
+    using System.Web;
+
+    using Moq;
+
+    [TestFixture]
+    public class ResolveFilePathTest
+    {
+        [Test]
+        public void EmptyPath_Throws()
+        {
+            var mockHttp = Mock.Of<HttpContextBase>();
+            var file = new BasicFile(ClientDependencyType.Javascript) { FilePath = "", };
+
+            Assert.Throws<ArgumentException>(() => file.ResolveFilePath(mockHttp));
+        }
+
+        [Test]
+        public void WhiteSpacePath_Throws()
+        {
+            var mockHttp = Mock.Of<HttpContextBase>();
+            var file = new BasicFile(ClientDependencyType.Javascript) { FilePath = "  ", };
+
+            Assert.Throws<ArgumentException>(() => file.ResolveFilePath(mockHttp));
+        }
+
+        [Test]
+        public void TildePath_IsResolved()
+        {
+            var mockHttp = Mock.Of<HttpContextBase>();
+            Mock.Get(mockHttp).DefaultValue = DefaultValue.Mock;
+            Mock.Get(mockHttp.Request).Setup(r => r.ApplicationPath).Returns("/");
+
+            var file = new BasicFile(ClientDependencyType.Javascript) { FilePath = "~/file.js", };
+
+            var resolvedPath = file.ResolveFilePath(mockHttp);
+
+            Assert.AreEqual("/file.js", resolvedPath);
+        }
+
+        [Test]
+        public void AbsoluteUrl_IsUnaltered()
+        {
+            var mockHttp = Mock.Of<HttpContextBase>();
+
+            var file = new BasicFile(ClientDependencyType.Javascript) { FilePath = "https://cdn.example.com/file.js", };
+
+            var resolvedPath = file.ResolveFilePath(mockHttp);
+
+            Assert.AreEqual("https://cdn.example.com/file.js", resolvedPath);
+        }
+
+        [Test]
+        public void AbsolutePath_IsUnaltered()
+        {
+            var mockHttp = Mock.Of<HttpContextBase>();
+
+            var file = new BasicFile(ClientDependencyType.Javascript) { FilePath = "/file.js", };
+
+            var resolvedPath = file.ResolveFilePath(mockHttp);
+
+            Assert.AreEqual("/file.js", resolvedPath);
+        }
+
+        [Test]
+        public void RelativePath_HasCurrentExecutionPathPrefixed()
+        {
+            var mockHttp = Mock.Of<HttpContextBase>();
+            Mock.Get(mockHttp).DefaultValue = DefaultValue.Mock;
+            Mock.Get(mockHttp.Request).Setup(r => r.AppRelativeCurrentExecutionFilePath).Returns("/the/path/page.aspx");
+
+            var file = new BasicFile(ClientDependencyType.Javascript) { FilePath = "file.js", };
+
+            var resolvedPath = file.ResolveFilePath(mockHttp);
+
+            Assert.AreEqual("/the/path/file.js", resolvedPath);
+        }
+    }
+}


### PR DESCRIPTION
When resolving the file path of an `IClientDependencyFile`, this adds path canonicalization, such that a file with a path of `/some/path/deeper/../test.js` will resolve to `/some/path/test.js`, which makes de-duplication of the script more effective.

Thanks for your consideration!