### PR TITLE
Fixed external imports when combining multiple CSS files

### DIFF
--- a/ClientDependency.Coffee/CoffeeWriter.cs
+++ b/ClientDependency.Coffee/CoffeeWriter.cs
@@ -9,6 +9,7 @@ using ClientDependency.Core.Config;
 using SassAndCoffee.Core;
 using SassAndCoffee.JavaScript;
 using SassAndCoffee.JavaScript.CoffeeScript;
+using System.Collections.Generic;
 
 namespace ClientDependency.Coffee
 {
@@ -17,7 +18,7 @@ namespace ClientDependency.Coffee
     /// </summary>
     public sealed class CoffeeWriter : IFileWriter
     {
-        public bool WriteToStream(BaseCompositeFileProcessingProvider provider, StreamWriter sw, FileInfo fi, ClientDependencyType type, string origUrl, HttpContextBase http)
+        public bool WriteToStream(BaseCompositeFileProcessingProvider provider, StreamWriter sw, FileInfo fi, ClientDependencyType type, string origUrl, HttpContextBase http, List<string> externalCssImports)
         {
             try
             {

--- a/ClientDependency.Core/CompositeFiles/IFileWriter.cs
+++ b/ClientDependency.Core/CompositeFiles/IFileWriter.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.Web;
 using ClientDependency.Core.CompositeFiles.Providers;
+using System.Collections.Generic;
 
 namespace ClientDependency.Core.CompositeFiles
 {
@@ -18,7 +19,8 @@ namespace ClientDependency.Core.CompositeFiles
         /// <param name="type"></param>
         /// <param name="origUrl"></param>
         /// <param name="http"></param>
+        /// <param name="externalCssImports"></param>
         /// <returns></returns>
-        bool WriteToStream(BaseCompositeFileProcessingProvider provider, StreamWriter sw, FileInfo fi, ClientDependencyType type, string origUrl, HttpContextBase http);
+        bool WriteToStream(BaseCompositeFileProcessingProvider provider, StreamWriter sw, FileInfo fi, ClientDependencyType type, string origUrl, HttpContextBase http, List<string> externalCssImports);
     }
 }

--- a/ClientDependency.Less/LessWriter.cs
+++ b/ClientDependency.Less/LessWriter.cs
@@ -24,7 +24,7 @@ namespace ClientDependency.Less
     {
 
         [SecuritySafeCritical]
-        public bool WriteToStream(BaseCompositeFileProcessingProvider provider, StreamWriter sw, FileInfo fi, ClientDependencyType type, string origUrl, HttpContextBase http)
+        public bool WriteToStream(BaseCompositeFileProcessingProvider provider, StreamWriter sw, FileInfo fi, ClientDependencyType type, string origUrl, HttpContextBase http, List<string> externalCssImports)
         {
             try
             {

--- a/ClientDependency.SASS/SassWriter.cs
+++ b/ClientDependency.SASS/SassWriter.cs
@@ -20,7 +20,7 @@ namespace ClientDependency.SASS
     {
         private static readonly ISassCompiler Compiler = new SassCompiler();
 
-        public bool WriteToStream(BaseCompositeFileProcessingProvider provider, StreamWriter sw, FileInfo fi, ClientDependencyType type, string origUrl, HttpContextBase http)
+        public bool WriteToStream(BaseCompositeFileProcessingProvider provider, StreamWriter sw, FileInfo fi, ClientDependencyType type, string origUrl, HttpContextBase http, List<string> externalCssImports)
         {
             try
             {

--- a/ClientDependency.TypeScript/TypeScriptWriter.cs
+++ b/ClientDependency.TypeScript/TypeScriptWriter.cs
@@ -9,12 +9,13 @@ using ClientDependency.Core.CompositeFiles.Providers;
 using ClientDependency.Core.Config;
 using SassAndCoffee.Core;
 using SassAndCoffee.JavaScript;
+using System.Collections.Generic;
 
 namespace ClientDependency.TypeScript
 {
     public sealed class TypeScriptWriter : IFileWriter
     {
-        public bool WriteToStream(BaseCompositeFileProcessingProvider provider, StreamWriter sw, FileInfo fi, ClientDependencyType type, string origUrl, HttpContextBase http)
+        public bool WriteToStream(BaseCompositeFileProcessingProvider provider, StreamWriter sw, FileInfo fi, ClientDependencyType type, string origUrl, HttpContextBase http, List<string> externalCssImports)
         {
             //if it is a file based dependency then read it				
             var fileContents = File.ReadAllText(fi.FullName, Encoding.UTF8); //read as utf 8

--- a/ClientDependency.UnitTests/CssImportStatementsTest.cs
+++ b/ClientDependency.UnitTests/CssImportStatementsTest.cs
@@ -9,38 +9,6 @@ namespace ClientDependency.UnitTests
     [TestFixture]
     public class CssImportStatementsTest
     {
-        [Test]
-        public void Retain_External_Imports()
-        {
-            var cssWithImport = @"@import url(""//fonts.googleapis.com/css?subset=latin,cyrillic-ext,latin-ext,cyrillic&family=Open+Sans+Condensed:300|Open+Sans:400,600,400italic,600italic|Merriweather:400,300,300italic,400italic,700,700italic|Roboto+Slab:400,300"");
-@import url(""//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css"");";
-
-            IEnumerable<string> importPaths;
-            var output = CssHelper.ParseImportStatements(cssWithImport, out importPaths);
-
-            Assert.AreEqual(cssWithImport, output);
-        }
-
-        [Test]
-        public void Retain_External_Imports_From_Stream()
-        {
-            var cssWithImport = @"@import url(""//fonts.googleapis.com/css?subset=latin,cyrillic-ext,latin-ext,cyrillic&family=Open+Sans+Condensed:300|Open+Sans:400,600,400italic,600italic|Merriweather:400,300,300italic,400italic,700,700italic|Roboto+Slab:400,300"");
-@import url(""//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css"");";
-
-            using (var ms = new MemoryStream())
-            using (var writer = new StreamWriter(ms))
-            {
-                writer.Write(cssWithImport);
-                writer.Flush();
-
-                string externalImports;
-                IEnumerable<string> importPaths;
-                var position = CssHelper.ParseImportStatements(ms, out importPaths, out externalImports);
-
-                Assert.AreEqual(ms.Length, position);
-                Assert.AreEqual(cssWithImport, externalImports);
-            }            
-        }
 
         [Test]
         public void Can_Parse_Import_Statements()
@@ -49,58 +17,28 @@ namespace ClientDependency.UnitTests
 @import url('/css/layout.css');
 @import url('http://mysite/css/color.css');
 @import url(/css/blah.css);
+@import url('//mysite/css/style.css');
 
 body { color: black; }
 div {display: block;}";
 
             IEnumerable<string> importPaths;
-            var output = CssHelper.ParseImportStatements(css, out importPaths);
+            IEnumerable<string> externalPaths;
+            var output = CssHelper.ParseImportStatements(css, out importPaths, out externalPaths);
 
-            Assert.AreEqual(@"@import url('http://mysite/css/color.css');
-
+            Assert.AreEqual(@"
 
 body { color: black; }
 div {display: block;}", output);
 
+            Assert.AreEqual(2, externalPaths.Count());
+            Assert.AreEqual("http://mysite/css/color.css", externalPaths.ElementAt(0));
+            Assert.AreEqual("//mysite/css/style.css", externalPaths.ElementAt(1));
+
             Assert.AreEqual(3, importPaths.Count());
             Assert.AreEqual("/css/typography.css", importPaths.ElementAt(0));
             Assert.AreEqual("/css/layout.css", importPaths.ElementAt(1));
-            //Assert.AreEqual("http://mysite/css/color.css", importPaths.ElementAt(2));
             Assert.AreEqual("/css/blah.css", importPaths.ElementAt(2));
-        }
-
-        [Test]
-        public void Can_Parse_Import_Statements_From_Stream()
-        {
-            var css = @"@import url('/css/typography.css');
-@import url('/css/layout.css');
-@import url('http://mysite/css/color.css');
-@import url(/css/blah.css);
-
-body { color: black; }
-div {display: block;}";
-
-            using (var ms = new MemoryStream())
-            using (var writer = new StreamWriter(ms))
-            {
-                writer.Write(css);
-                writer.Flush();
-
-                IEnumerable<string> importPaths;
-                string externalImports;
-                var position = CssHelper.ParseImportStatements(ms, out importPaths, out externalImports);
-
-                Assert.AreEqual(@"@import url('http://mysite/css/color.css');", externalImports);
-
-                Assert.AreEqual(3, importPaths.Count());
-                Assert.AreEqual("/css/typography.css", importPaths.ElementAt(0));
-                Assert.AreEqual("/css/layout.css", importPaths.ElementAt(1));
-                //Assert.AreEqual("http://mysite/css/color.css", importPaths.ElementAt(2));
-                Assert.AreEqual("/css/blah.css", importPaths.ElementAt(2));
-
-            }
-
-            
         }
     }
 }


### PR DESCRIPTION
This fixes external @import CSS calls.

The problem that I've run into is that when I import, for example, a Google font with:

```
@import url(https://fonts.googleapis.com/css?family=Exo+2);
```

Google returns the font based on the User agent from which the request came from. So, most likely you'll get one font format for Firefox or Chrome and another for IE.

This sometimes created problems with rendering fonts in some browsers (most often IE).

That's one example why I don't think it's good to combine external CSS calls. This solution moves any external @import calls from any CSS file that is combined to the top of the combined CSS (a @import statement is only valid if it comes before any CSS rules, except @charset).

There's a problem with one unit test, but I didn't bother to fix it because I couldn't debug the test. I'm sure it's an easy fix.
