### PR TITLE
Fix bug with multiple values in HtmlAttributes

### DIFF
--- a/ClientDependency.Core/HtmlAttributesStringParser.cs
+++ b/ClientDependency.Core/HtmlAttributesStringParser.cs
@@ -61,6 +61,8 @@ namespace ClientDependency.Core
 
                         //now we can add/replace the current value to the dictionary
                         destination[key] = val;
+                        key = "";
+                        val = "";
                         continue;
                     }
                     


### PR DESCRIPTION
When parsing the `HtmlAttributesAsString` property, the keys and values accumulate, so that when there are multiple key/value pairs, the keys and values are duplicated.  For example, `HtmlAttributesAsString="defer=true,async=true"` yields the following:

    defer=true
    deferasync=truetrue