### PR TITLE
We should ensure that current file stream is at position "0".

### DIFF
--- a/ClientDependency.Core/CompositeFiles/Providers/BaseCompositeFileProcessingProvider.cs
+++ b/ClientDependency.Core/CompositeFiles/Providers/BaseCompositeFileProcessingProvider.cs
@@ -601,6 +601,12 @@ namespace ClientDependency.Core.CompositeFiles.Providers
         {
             Func<Stream, string> streamToString = stream =>
             {
+                if (!stream.CanRead)
+                    throw new InvalidOperationException("Cannot read input stream");
+
+                if (stream.CanSeek)
+                    stream.Position = 0;
+
                 var reader = new StreamReader(stream);
                 return reader.ReadToEnd();
             };


### PR DESCRIPTION
There was a bug when property "enableCssMinify" is set to "false" in ClientDependency.config file AND property "debug" is set to "false" in Web.config file. The stream is not at position "0". So the ouput result is an empty css style sheet.