### PR TITLE
Upgrade Clientdependency.less to .net Framework 4.6.1

### DIFF
--- a/ClientDependency.Less/ClientDependency.Less.csproj
+++ b/ClientDependency.Less/ClientDependency.Less.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ClientDependency.Less</RootNamespace>
     <AssemblyName>ClientDependency.Less</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -24,6 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>SecurityRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,6 +34,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <RunCodeAnalysis>false</RunCodeAnalysis>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="dotless.Core, Version=1.5.0.0, Culture=neutral, PublicKeyToken=96b446c9e63eae34, processorArchitecture=MSIL">

--- a/ClientDependency.Mvc/packages.config
+++ b/ClientDependency.Mvc/packages.config
@@ -4,7 +4,7 @@
   <package id="Microsoft.AspNet.Razor" version="2.0.20715.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.WebPages" version="2.0.20710.0" targetFramework="net40" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net40" />
-  <package id="Microsoft.AspNet.Mvc" version="5.0.0" targetFramework="net45" />
+  <!--<package id="Microsoft.AspNet.Mvc" version="5.0.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.0.0" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebPages" version="3.0.0" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebPages" version="3.0.0" targetFramework="net45" />-->
 </packages>

--- a/ClientDependency.Web.Test/ClientDependency.Web.Test.csproj
+++ b/ClientDependency.Web.Test/ClientDependency.Web.Test.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ClientDependency.Web.Test</RootNamespace>
     <AssemblyName>ClientDependency.Web.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <SccProjectName>
     </SccProjectName>
     <SccLocalPath>

--- a/ClientDependency.Web.Test/Web.config
+++ b/ClientDependency.Web.Test/Web.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0"?>
 <!-- 
 // TODO:
 * Add the config section
@@ -10,8 +10,8 @@
 <configuration>
   <configSections>
     <!-- Need to register the clientDependency config section -->
-    <section name="clientDependency" type="ClientDependency.Core.Config.ClientDependencySection, ClientDependency.Core" requirePermission="false" />
-    <section name="dotless" type="dotless.Core.configuration.DotlessConfigurationSectionHandler, dotless.Core" requirePermission="false" />
+    <section name="clientDependency" type="ClientDependency.Core.Config.ClientDependencySection, ClientDependency.Core" requirePermission="false"/>
+    <section name="dotless" type="dotless.Core.configuration.DotlessConfigurationSectionHandler, dotless.Core" requirePermission="false"/>
   </configSections>
   <!-- 
 Customize the configuration section as required, it is optional,
@@ -35,17 +35,17 @@ Composite files are used for both types of projects.
   -->
     <fileRegistration defaultProvider="PlaceHolderProvider">
       <providers>
-        <add name="PageHeaderProvider" type="ClientDependency.Core.FileRegistration.Providers.PageHeaderProvider, ClientDependency.Core" enableCompositeFiles="true" />
-        <add name="LazyLoadProvider" type="ClientDependency.Core.FileRegistration.Providers.LazyLoadProvider, ClientDependency.Core" enableCompositeFiles="true" />
-        <add name="LoaderControlProvider" type="ClientDependency.Core.FileRegistration.Providers.LoaderControlProvider, ClientDependency.Core" enableCompositeFiles="true" />
-        <add name="PlaceHolderProvider" type="ClientDependency.Core.FileRegistration.Providers.PlaceHolderProvider, ClientDependency.Core" enableCompositeFiles="true" javascriptPlaceHolderId="JavaScriptPlaceHolder" cssPlaceHolderId="CssPlaceHolder" />
+        <add name="PageHeaderProvider" type="ClientDependency.Core.FileRegistration.Providers.PageHeaderProvider, ClientDependency.Core" enableCompositeFiles="true"/>
+        <add name="LazyLoadProvider" type="ClientDependency.Core.FileRegistration.Providers.LazyLoadProvider, ClientDependency.Core" enableCompositeFiles="true"/>
+        <add name="LoaderControlProvider" type="ClientDependency.Core.FileRegistration.Providers.LoaderControlProvider, ClientDependency.Core" enableCompositeFiles="true"/>
+        <add name="PlaceHolderProvider" type="ClientDependency.Core.FileRegistration.Providers.PlaceHolderProvider, ClientDependency.Core" enableCompositeFiles="true" javascriptPlaceHolderId="JavaScriptPlaceHolder" cssPlaceHolderId="CssPlaceHolder"/>
       </providers>
     </fileRegistration>
     <!-- This section is used for MVC only -->
     <mvc defaultRenderer="StandardRenderer">
       <renderers>
-        <add name="StandardRenderer" type="ClientDependency.Core.FileRegistration.Providers.StandardRenderer, ClientDependency.Core" enableCompositeFiles="true" disableCompositeBundling="false" enableDebugVersionQueryString="true" />
-        <add name="LazyLoadRenderer" type="ClientDependency.Core.FileRegistration.Providers.LazyLoadRenderer, ClientDependency.Core" />
+        <add name="StandardRenderer" type="ClientDependency.Core.FileRegistration.Providers.StandardRenderer, ClientDependency.Core" enableCompositeFiles="true" disableCompositeBundling="false" enableDebugVersionQueryString="true"/>
+        <add name="LazyLoadRenderer" type="ClientDependency.Core.FileRegistration.Providers.LazyLoadRenderer, ClientDependency.Core"/>
       </renderers>
     </mvc>
     <!-- 
@@ -65,13 +65,13 @@ to be recreated again and will be based on the persisted file on disk. This save
     since Cassini does not support '.' chars in the path.
     -->
       <fileProcessingProviders>
-        <add name="CompositeFileProcessor" type="ClientDependency.Core.CompositeFiles.Providers.CompositeFileProcessingProvider, ClientDependency.Core" enableCssMinify="true" enableJsMinify="true" persistFiles="false" compositeFilePath="~/App_Data/ClientDependency" bundleDomains="localhost:54153,ajax.googleapis.com" urlType="Base64QueryStrings" pathUrlFormat="{dependencyId}/{version}/{type}" />
+        <add name="CompositeFileProcessor" type="ClientDependency.Core.CompositeFiles.Providers.CompositeFileProcessingProvider, ClientDependency.Core" enableCssMinify="true" enableJsMinify="true" persistFiles="false" compositeFilePath="~/App_Data/ClientDependency" bundleDomains="localhost:54153,ajax.googleapis.com" urlType="Base64QueryStrings" pathUrlFormat="{dependencyId}/{version}/{type}"/>
       </fileProcessingProviders>
       <!-- 
     A file map provider stores references to dependency files by an id to be used in the handler URL when using the MappedId Url type
     -->
       <fileMapProviders>
-        <add name="XmlFileMap" type="ClientDependency.Core.CompositeFiles.Providers.XmlFileMapper, ClientDependency.Core" mapPath="~/App_Data/ClientDependency" />
+        <add name="XmlFileMap" type="ClientDependency.Core.CompositeFiles.Providers.XmlFileMapper, ClientDependency.Core" mapPath="~/App_Data/ClientDependency"/>
       </fileMapProviders>
       <!--  
   Defines the mime types to compress when requested by the client.
@@ -80,7 +80,7 @@ to be recreated again and will be based on the persisted file on disk. This save
   such as JSON or XML ajax requests.
   -->
       <mimeTypeCompression>
-        <add type="application/json" path="^.*?/Services/.*" />
+        <add type="application/json" path="^.*?/Services/.*"/>
       </mimeTypeCompression>
       <!-- 
   Defines the paths to match on to enable rogue file compression.
@@ -97,7 +97,7 @@ to be recreated again and will be based on the persisted file on disk. This save
       </rogueFileCompression>
     </compositeFiles>
   </clientDependency>
-  <connectionStrings />
+  <connectionStrings/>
   <!--
     For a description of web.config changes for .NET 4.5 see http://go.microsoft.com/fwlink/?LinkId=235367.
 
@@ -107,101 +107,98 @@ to be recreated again and will be based on the persisted file on disk. This save
       </system.Web>
   -->
   <system.web>
-    <trace enabled="false" pageOutput="true" />
-    <httpRuntime maxRequestLength="8192" maxUrlLength="8192" maxQueryStringLength="8192" />
+    <trace enabled="false" pageOutput="true"/>
+    <httpRuntime maxRequestLength="8192" maxUrlLength="8192" maxQueryStringLength="8192"/>
     <!--<trust level="Medium" originUrl=".*" />-->
-    <compilation debug="false" targetFramework="4.5">
+    <compilation debug="false" targetFramework="4.6.1">
       <assemblies>
-        <add assembly="System.Web.Mvc, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
-        <add assembly="System.Web.Abstractions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
-        <add assembly="System.Web.Routing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
-        <add assembly="System.Data.Linq, Version=4.0.0.0, Culture=neutral, PublicKeyToken=B77A5C561934E089" />
+        <add assembly="System.Web.Mvc, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35"/>
+        <add assembly="System.Web.Abstractions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35"/>
+        <add assembly="System.Web.Routing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35"/>
+        <add assembly="System.Data.Linq, Version=4.0.0.0, Culture=neutral, PublicKeyToken=B77A5C561934E089"/>
       </assemblies>
     </compilation>
-    <authentication mode="Forms" />
-    <customErrors mode="Off" />
+    <authentication mode="Forms"/>
+    <customErrors mode="Off"/>
     <pages controlRenderingCompatibilityVersion="4.0" clientIDMode="AutoID">
       <namespaces>
-        <add namespace="System.Web.Mvc" />
-        <add namespace="System.Web.Mvc.Ajax" />
-        <add namespace="System.Web.Mvc.Html" />
-        <add namespace="System.Web.Routing" />
-        <add namespace="System.Linq" />
-        <add namespace="System.Collections.Generic" />
+        <add namespace="System.Web.Mvc"/>
+        <add namespace="System.Web.Mvc.Ajax"/>
+        <add namespace="System.Web.Mvc.Html"/>
+        <add namespace="System.Web.Routing"/>
+        <add namespace="System.Linq"/>
+        <add namespace="System.Collections.Generic"/>
       </namespaces>
     </pages>
     <httpHandlers>
       <!-- ** Need to add the dependency handler -->
-      <add verb="GET" path="DependencyHandler.axd" type="ClientDependency.Core.CompositeFiles.CompositeDependencyHandler, ClientDependency.Core " />
-      <add path="*.coffee" verb="GET" type="ClientDependency.Coffee.CoffeeHandler, ClientDependency.Coffee" />
-      <add path="*.sass,*.scss" verb="GET" type="ClientDependency.SASS.SassHandler, ClientDependency.SASS" />
-      <add path="*.ts" verb="GET" type="ClientDependency.TypeScript.TypeScriptHandler, ClientDependency.TypeScript" />
-      <add path="*.less" verb="GET" type="dotless.Core.LessCssHttpHandler, dotless.Core" />
-      
+      <add verb="GET" path="DependencyHandler.axd" type="ClientDependency.Core.CompositeFiles.CompositeDependencyHandler, ClientDependency.Core "/>
+      <add path="*.coffee" verb="GET" type="ClientDependency.Coffee.CoffeeHandler, ClientDependency.Coffee"/>
+      <add path="*.sass,*.scss" verb="GET" type="ClientDependency.SASS.SassHandler, ClientDependency.SASS"/>
+      <add path="*.ts" verb="GET" type="ClientDependency.TypeScript.TypeScriptHandler, ClientDependency.TypeScript"/>
+      <add path="*.less" verb="GET" type="dotless.Core.LessCssHttpHandler, dotless.Core"/>
     </httpHandlers>
     <httpModules>
       <!-- ** Need to add the dependency module -->
-      <add name="ClientDependencyModule" type="ClientDependency.Core.Module.ClientDependencyModule, ClientDependency.Core" />
+      <add name="ClientDependencyModule" type="ClientDependency.Core.Module.ClientDependencyModule, ClientDependency.Core"/>
     </httpModules>
   </system.web>
   <system.webServer>
-    <validation validateIntegratedModeConfiguration="false" />
+    <validation validateIntegratedModeConfiguration="false"/>
     <modules runAllManagedModulesForAllRequests="true">
-      <remove name="ClientDependencyModule" />
+      <remove name="ClientDependencyModule"/>
       <!-- ** Need to add the dependency module -->
-      <add name="ClientDependencyModule" type="ClientDependency.Core.Module.ClientDependencyModule, ClientDependency.Core" />
+      <add name="ClientDependencyModule" type="ClientDependency.Core.Module.ClientDependencyModule, ClientDependency.Core"/>
     </modules>
     <handlers>
-      <remove name="UrlRoutingHandler" />
+      <remove name="UrlRoutingHandler"/>
       <!-- ** Need to add the dependency handler -->
-      <remove name="DependencyHandler" />
-      <add name="DependencyHandler" preCondition="integratedMode" verb="GET" path="DependencyHandler.axd" type="ClientDependency.Core.CompositeFiles.CompositeDependencyHandler, ClientDependency.Core " />
+      <remove name="DependencyHandler"/>
+      <add name="DependencyHandler" preCondition="integratedMode" verb="GET" path="DependencyHandler.axd" type="ClientDependency.Core.CompositeFiles.CompositeDependencyHandler, ClientDependency.Core "/>
       <!-- ** CDF Plugin handlers -->
-      <remove name="CdfCoffeeHandler" />
-      <remove name="CdfSasSHandler" />
-      <remove name="CdfScssHandler" />
-      <remove name="CdfTypeScriptHandler" />
-      <remove name="dotless" />
-      <add name="CdfCoffeeHandler" path="*.coffee" verb="GET" type="ClientDependency.Coffee.CoffeeHandler, ClientDependency.Coffee" resourceType="File" preCondition="" />
-      <add name="CdfSasSHandler" path="*.sass" verb="GET" type="ClientDependency.SASS.SassHandler, ClientDependency.SASS" resourceType="File" preCondition="" />
-      <add name="CdfScssHandler" path="*.scss" verb="GET" type="ClientDependency.SASS.SassHandler, ClientDependency.SASS" resourceType="File" preCondition="" />
-      <add name="CdfTypeScriptHandler" path="*.ts" verb="GET" type="ClientDependency.TypeScript.TypeScriptHandler, ClientDependency.TypeScript" resourceType="File" preCondition="" />
-      <add name="dotless" path="*.less" verb="GET" type="dotless.Core.LessCssHttpHandler,dotless.Core" resourceType="File" preCondition="" />
-      
+      <remove name="CdfCoffeeHandler"/>
+      <remove name="CdfSasSHandler"/>
+      <remove name="CdfScssHandler"/>
+      <remove name="CdfTypeScriptHandler"/>
+      <remove name="dotless"/>
+      <add name="CdfCoffeeHandler" path="*.coffee" verb="GET" type="ClientDependency.Coffee.CoffeeHandler, ClientDependency.Coffee" resourceType="File" preCondition=""/>
+      <add name="CdfSasSHandler" path="*.sass" verb="GET" type="ClientDependency.SASS.SassHandler, ClientDependency.SASS" resourceType="File" preCondition=""/>
+      <add name="CdfScssHandler" path="*.scss" verb="GET" type="ClientDependency.SASS.SassHandler, ClientDependency.SASS" resourceType="File" preCondition=""/>
+      <add name="CdfTypeScriptHandler" path="*.ts" verb="GET" type="ClientDependency.TypeScript.TypeScriptHandler, ClientDependency.TypeScript" resourceType="File" preCondition=""/>
+      <add name="dotless" path="*.less" verb="GET" type="dotless.Core.LessCssHttpHandler,dotless.Core" resourceType="File" preCondition=""/>
     </handlers>
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+        <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-1.1.0.0" newVersion="1.1.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="0.0.0.0-1.5.2.14234" newVersion="1.5.2.14234" />
+        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.5.2.14234" newVersion="1.5.2.14234"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Razor" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+        <assemblyIdentity name="System.Web.Razor" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.WebPages.Razor" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+        <assemblyIdentity name="System.Web.WebPages.Razor" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-  <dotless minifyCss="false" cache="true" web="false" strictMath="false" />
-  
+  <dotless minifyCss="false" cache="true" web="false" strictMath="false"/>
 </configuration>


### PR DESCRIPTION
DotNet framework 4.6.1+ is required to support dotless 1.6.4 