### PR TITLE
let css import statements have a space (or more) before the ;

### DIFF
--- a/ClientDependency.Core/CssHelper.cs
+++ b/ClientDependency.Core/CssHelper.cs
@@ -10,7 +10,7 @@ namespace ClientDependency.Core
 {
     internal static class CssHelper
     {
-        private static readonly Regex ImportCssRegex = new Regex(@"@import url\((.+?)\);?", RegexOptions.Compiled);
+        private static readonly Regex ImportCssRegex = new Regex(@"@import url\((.+?)\)\s*?;?", RegexOptions.Compiled);
         private static readonly Regex CssUrlRegex = new Regex(@"url\(((?![""']?data:|[""']?#).+?)\)", RegexOptions.Compiled);
 
         /// <summary>

--- a/SolutionInfo.cs
+++ b/SolutionInfo.cs
@@ -7,6 +7,6 @@ using System.Security;
 [assembly: AssemblyCulture("")]
 
 
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
-[assembly: AssemblyInformationalVersion("2.0.0.0beta")]
+[assembly: AssemblyVersion("1.9.6")]
+[assembly: AssemblyFileVersion("1.9.6")]
+[assembly: AssemblyInformationalVersion("1.9.6")]

--- a/SolutionInfo.cs
+++ b/SolutionInfo.cs
@@ -7,6 +7,6 @@ using System.Security;
 [assembly: AssemblyCulture("")]
 
 
-[assembly: AssemblyVersion("1.9.6")]
-[assembly: AssemblyFileVersion("1.9.6")]
-[assembly: AssemblyInformationalVersion("1.9.6")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]
+[assembly: AssemblyInformationalVersion("2.0.0.0beta")]


### PR DESCRIPTION
Its not really in the css spec but browsers do let you have a space after the @import url() statement and the ; 

So with CDF turned off

```@import url('styles.css') ;```

works but when it is turned back on the css file isn't included because the regex doesn't find the import statement. 