### PR TITLE
Setting explicit version for dotless dependency

### DIFF
--- a/build/ClientDependency-Less.nuspec
+++ b/build/ClientDependency-Less.nuspec
@@ -15,7 +15,7 @@
     <copyright>Copyright © Shannon Deminick $copyrightyear$</copyright>
     <repository type="git" url="https://github.com/Shandem/ClientDependency" />
     <dependencies>
-      <dependency id="dotless" version="1.5" />
+      <dependency id="dotless" version="[1.5.2]" />
       <dependency id="ClientDependency" version="1.8" />
     </dependencies>
   </metadata>

--- a/src/ClientDependency.Less/packages.config
+++ b/src/ClientDependency.Less/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="dotless" version="1.5.0" targetFramework="net40" />
+  <package id="dotless" version="1.5.2" targetFramework="net40" />
   <package id="Microsoft.Build.Tasks.Git" version="1.0.0-beta2-18618-05" targetFramework="net40" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.0.0-beta2-18618-05" targetFramework="net40" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.0.0-beta2-18618-05" targetFramework="net40" developmentDependency="true" />

--- a/src/ClientDependency.Web.Test/packages.config
+++ b/src/ClientDependency.Web.Test/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="dotless" version="1.5.0" targetFramework="net45" />
+  <package id="dotless" version="1.5.2" targetFramework="net45" />
   <package id="IronRuby" version="1.1.3" targetFramework="net40" />
   <package id="Microsoft.AspNet.Mvc" version="5.0.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.0.0" targetFramework="net45" />


### PR DESCRIPTION
This PR is setting an explicit version for dotless to avoid issues when the latest version is installed with ClientDependency.

Ref-issue: https://github.com/Shazwazza/ClientDependency/issues/181