### PR TITLE
Make the constructor public

### DIFF
--- a/src/ClientDependency.Core/CompositeFiles/CompositeFileMap.cs
+++ b/src/ClientDependency.Core/CompositeFiles/CompositeFileMap.cs
@@ -13,7 +13,7 @@ namespace ClientDependency.Core.CompositeFiles
 	public class CompositeFileMap
 	{
 
-		internal CompositeFileMap(string key, string compressionType, string file, IEnumerable<string> filePaths, int version)
+		public CompositeFileMap(string key, string compressionType, string file, IEnumerable<string> filePaths, int version)
 		{
             DependentFiles = filePaths;
 			FileKey = key;


### PR DESCRIPTION
So we can easily extend the providers overriding the functions that return this class.
The previous fix Serializing and deserializing using json doesn't work anymore.